### PR TITLE
Fix issue where menu traps all keys

### DIFF
--- a/packages/menu/MenuList.svelte
+++ b/packages/menu/MenuList.svelte
@@ -17,6 +17,7 @@
 
   const currentCandidate = writable(undefined);
   const allItems = writable([]);
+  let ref;
 
   setContext("currentCandidate", currentCandidate);
   setContext("allItems", allItems);
@@ -43,11 +44,25 @@
   }
 
   const handleKeypress = (event) => {
+    if (document.activeElement !== ref) return;
+
     const { key } = event;
+
     if (key !== "Tab") event.preventDefault();
-    if (key === "ArrowUp") previous();
-    if (key === "ArrowDown") next();
-    if (key === "Enter") select();
+
+    switch (key) {
+      case "ArrowUp":
+        previous();
+        break;
+      case "ArrowDown":
+        next();
+        break;
+      case "Enter":
+        select();
+        break;
+      default:
+        break;
+    }
   };
 </script>
 
@@ -66,6 +81,6 @@
 
 <svelte:window on:keydown={handleKeypress} />
 
-<ul transition:fly={{ duration: 100, y: -5 }} on:selection>
+<ul bind:this={ref} transition:fly={{ duration: 100, y: -5 }} on:selection>
   <slot />
 </ul>

--- a/packages/optionmenu/stories/SideBySideStory.svelte
+++ b/packages/optionmenu/stories/SideBySideStory.svelte
@@ -13,6 +13,18 @@
     width: 65vw;
   }
 
+  #toolbar {
+    align-items: center;
+    display: grid;
+    grid-auto-flow: column;
+    justify-content: space-between;
+  }
+
+  #filename {
+    font-size: 0.8em;
+    margin: 0;
+  }
+
   #menus {
     background: #fff;
     display: grid;
@@ -61,44 +73,47 @@
   --text-decoration: ${formatting.includes('underline') ? 'underline' : 'none'};
   --text-align: ${textAlign};
 `}>
-  <div id="menus">
-    <OptionMenu
-      on:selection={({ detail: { key } }) => {
-        fontSize = key;
-      }}>
-      <Option selected={fontSize === '16px'} key="16px" label="16px" />
-      <Option selected={fontSize === '24px'} key="24px" label="24px" />
-      <Option selected={fontSize === '32px'} key="32px" label="32px" />
-    </OptionMenu>
-    <OptionMenu
-      multi
-      on:selection={({ detail: { keys } }) => {
-        formatting = keys;
-      }}>
-      <Option selected={formatting.includes('bold')} key="bold" label="Bold">
-        <span slot="right" class="bold">B</span>
-      </Option>
-      <Option
-        selected={formatting.includes('italic')}
-        key="italic"
-        label="Italic">
-        <span slot="right" class="italic">I</span>
-      </Option>
-      <Option
-        selected={formatting.includes('underline')}
-        key="underline"
-        label="Underlined">
-        <span slot="right" class="underline">U</span>
-      </Option>
-    </OptionMenu>
-    <OptionMenu
-      on:selection={({ detail: { key } }) => {
-        textAlign = key;
-      }}>
-      <Option selected={textAlign === 'left'} key="left" label="Left" />
-      <Option selected={textAlign === 'center'} key="center" label="Center" />
-      <Option selected={textAlign === 'right'} key="right" label="Right" />
-    </OptionMenu>
+  <div id="toolbar">
+    <input id="filename" type="text" placeholder="Filename" />
+    <div id="menus">
+      <OptionMenu
+        on:selection={({ detail: { key } }) => {
+          fontSize = key;
+        }}>
+        <Option selected={fontSize === '16px'} key="16px" label="16px" />
+        <Option selected={fontSize === '24px'} key="24px" label="24px" />
+        <Option selected={fontSize === '32px'} key="32px" label="32px" />
+      </OptionMenu>
+      <OptionMenu
+        multi
+        on:selection={({ detail: { keys } }) => {
+          formatting = keys;
+        }}>
+        <Option selected={formatting.includes('bold')} key="bold" label="Bold">
+          <span slot="right" class="bold">B</span>
+        </Option>
+        <Option
+          selected={formatting.includes('italic')}
+          key="italic"
+          label="Italic">
+          <span slot="right" class="italic">I</span>
+        </Option>
+        <Option
+          selected={formatting.includes('underline')}
+          key="underline"
+          label="Underlined">
+          <span slot="right" class="underline">U</span>
+        </Option>
+      </OptionMenu>
+      <OptionMenu
+        on:selection={({ detail: { key } }) => {
+          textAlign = key;
+        }}>
+        <Option selected={textAlign === 'left'} key="left" label="Left" />
+        <Option selected={textAlign === 'center'} key="center" label="Center" />
+        <Option selected={textAlign === 'right'} key="right" label="Right" />
+      </OptionMenu>
+    </div>
   </div>
   <p>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum congue


### PR DESCRIPTION
## Steps to test this in GLAM

1. Navigate to the graph-paper working directory, then the `packages/menu` directory
2. Run `npm link`
3. Navigate to the `packages/optionmenu` directory
4. Run `npm link @graph-paper/menu`
5. Run `npm link`
6. Navigate to the glam working directory
7. Run `npm link @graph-paper/optionmenu`
8. Stop and restart `npm run dev`
9. Visit [this probe](http://localhost:5000/firefox/probe/gc_minor_reason/explore)