### PR TITLE
@graph-paper/stack: use owl selectors to allow smooth slide in/out transitions instead of grid-column-gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## unreeleased
+## unreleased
 
 - Re-implement the `Stack` component to use owl selectors instead of
   `grid-column-gap`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreeleased
+
+- Re-implement the `Stack` component to use owl selectors instead of
+  `grid-column-gap`
+  ([#56](https://github.com/graph-paper-org/graph-paper/pull/56))
+
 ## 0.0.0-alpha.14
 
 Published `2020-06-29`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
   `grid-column-gap`
   ([#56](https://github.com/graph-paper-org/graph-paper/pull/56))
 
+## 0.0.0-alpha.15
+
+Published `2020-07-16`
+
+- Fix issue where `OptionMenu` traps keypresses
+  ([#54](https://github.com/graph-paper-org/graph-paper/pull/54))
+
 ## 0.0.0-alpha.14
 
 Published `2020-06-29`

--- a/packages/button/style.css
+++ b/packages/button/style.css
@@ -11,7 +11,6 @@
   padding-left: var(--space-2x);
   padding-right: var(--space-2x);
   font-weight: 500;
-  margin: 0;
   display: flex;
   column-gap: var(--space-base);
   text-align: center;

--- a/packages/core/style.css
+++ b/packages/core/style.css
@@ -299,6 +299,7 @@ button {
   color: #333;
   background-color: #f4f4f4;
   outline: none;
+  margin: 0px;
 }
 
 button:active {

--- a/packages/elements/package-lock.json
+++ b/packages/elements/package-lock.json
@@ -4,52 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@graph-paper/button": {
-      "version": "0.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@graph-paper/button/-/button-0.0.0-alpha.10.tgz",
-      "integrity": "sha512-cvLOAwnZ6P92CrBcBh2BRTVL/J+YQpiPCu/NO2oxK1v2c7NwH/7dwE0hlCPOlB30ihU+w0FzBntKGvn/nMD2Ag==",
-      "dev": true,
-      "requires": {
-        "@graph-paper/core": "^0.0.0-alpha.10"
-      }
-    },
-    "@graph-paper/chip": {
-      "version": "0.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@graph-paper/chip/-/chip-0.0.0-alpha.10.tgz",
-      "integrity": "sha512-iJuxb5QKQE4BF1V+tm4nkay5d7mZpeTbyGyn7VbH51cTgA0fpGxAqzasqdOHpQsJ8E0h9XKuAFL37SDQTC79eQ==",
-      "dev": true,
-      "requires": {
-        "@graph-paper/icons": "^0.0.0-alpha.10"
-      }
-    },
-    "@graph-paper/core": {
-      "version": "0.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@graph-paper/core/-/core-0.0.0-alpha.10.tgz",
-      "integrity": "sha512-5rAJN3rKnlLWgvY6E4sX4o+cxAH++JwgFMnaSsxcSgwZTbRl+QK2T1ZuWCCLyv3rwLOKOZnA3O7tvkmGaoOGoQ==",
-      "dev": true
-    },
-    "@graph-paper/datagraphic": {
-      "version": "0.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@graph-paper/datagraphic/-/datagraphic-0.0.0-alpha.10.tgz",
-      "integrity": "sha512-JgcoCdKA6atzIPTIN/zhZ+j86RFrX88DGUeRYezBEAOm1bMgOdyxv0+FXEIpAZhTAquzr1MCBcaz2COwhomkOw==",
-      "dev": true,
-      "requires": {
-        "d3-array": "^2.4.0",
-        "d3-scale": "^3.2.1"
-      }
-    },
-    "@graph-paper/guides": {
-      "version": "0.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@graph-paper/guides/-/guides-0.0.0-alpha.10.tgz",
-      "integrity": "sha512-EzppPh78FYKAyS54qV8mYS1nd6qD76e9NROFg6cvHrFolSzReKteNTF1gIe1Nz0qsmtlXOrcXQ8eNMp6D2fdFQ==",
-      "dev": true
-    },
-    "@graph-paper/icons": {
-      "version": "0.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@graph-paper/icons/-/icons-0.0.0-alpha.10.tgz",
-      "integrity": "sha512-tkkN7tMk5aUuUkr6rcPwBPsmM9NAPSikZezYmSXsEqCQTc2EQcKm+8oSBLmrrBHpC7dsFhtkE1dtljMUX0wbbw==",
-      "dev": true
-    },
     "d3-array": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.4.0.tgz",

--- a/packages/stack/stories/ColorPalette.svelte
+++ b/packages/stack/stories/ColorPalette.svelte
@@ -65,7 +65,14 @@
     <Axis side="left" />
     {#each colors as color, i (color.bg)}
       <g transition:fade={{ duration: 200 }}>
-        <Point x={color.value} y="Magma" color={color.bg} size={3} stroke={interpolateMagma(0)} strokeWidth={1} strokeAlpha={.5} />
+        <Point
+          x={color.value}
+          y="Magma"
+          color={color.bg}
+          size={3}
+          stroke={interpolateMagma(0)}
+          strokeWidth={1}
+          strokeAlpha={0.5} />
       </g>
     {/each}
   </DataGraphic>

--- a/packages/stack/stories/ColorPalette.svelte
+++ b/packages/stack/stories/ColorPalette.svelte
@@ -1,0 +1,59 @@
+<script>
+import { slide } from 'svelte/transition';
+import { interpolateMagma } from 'd3-scale-chromatic';
+import { Stack } from '../';
+import { Button } from '../../button'
+import { Add } from '../../icons'
+
+function generateColor() {
+  const index = Math.random();
+  const r = Math.random();
+  const r2 = Math.random();
+  const text = r > .5 ? 0 : 1;
+  return {bg: interpolateMagma(r), text: interpolateMagma(text), index};
+}
+
+let colors = Array.from({length:3}).map(generateColor);
+
+function remove(i) {
+  return () => {
+    colors = colors.filter((di) => di.index !== i );
+  }
+}
+
+</script>
+
+<style>
+h2 {
+  margin:0px;
+}
+
+.color {
+  --bg: transparent;
+  --text: black;
+  background-color: var(--bg);
+  color: var(--text);
+  border: none;
+  transition: box-shadow 100ms;
+}
+
+.color:hover {
+  box-shadow: 3px 3px 0px var(--hover);
+}
+</style>
+
+
+<Stack space={4} justifyContent=start justifyItems=start>
+  <h2>Color Palette</h2>
+  <Button level=medium on:click={() => { colors = [...colors, generateColor()]}}>add color <Add size=1em /></Button>
+  <div style="width: var(--space-24x);">
+<Stack>
+  {#each colors as { bg, text, index}, i (index)}
+    <button on:click={remove(index)} transition:slide={{duration: 500}} class=color style="--bg:{bg}; --text: {text};">
+      {bg}
+    </button>
+  {/each}
+</Stack>
+</div>
+
+</Stack>

--- a/packages/stack/stories/ColorPalette.svelte
+++ b/packages/stack/stories/ColorPalette.svelte
@@ -84,12 +84,12 @@
     add color
     <Add size="1em" />
   </Button>
-  <div style="width: var(--space-24x);">
+  <div style="width: var(--space-24x); outline: 1px solid lightgray;">
     <Stack>
       {#each colors as { bg, text, index }, i (index)}
         <button
           on:click={remove(index)}
-          transition:slide={{ duration: 200 }}
+          transition:slide={{ duration: 400 }}
           class="color"
           style="--bg:{bg}; --text: {text};">
           {bg}

--- a/packages/stack/stories/ColorPalette.svelte
+++ b/packages/stack/stories/ColorPalette.svelte
@@ -1,59 +1,94 @@
 <script>
-import { slide } from 'svelte/transition';
-import { interpolateMagma } from 'd3-scale-chromatic';
-import { Stack } from '../';
-import { Button } from '../../button'
-import { Add } from '../../icons'
+  // eslint-disable-next-line import/no-extraneous-dependencies
+  import { slide, fade } from "svelte/transition";
+  // eslint-disable-next-line import/no-extraneous-dependencies
+  import { interpolateMagma } from "d3-scale-chromatic";
+  import { Stack } from "..";
+  import { Button } from "../../button";
+  import { Add } from "../../icons";
+  import { DataGraphic } from "../../datagraphic";
+  import { Point } from "../../elements";
+  import { Axis } from "../../guides";
 
-function generateColor() {
-  const index = Math.random();
-  const r = Math.random();
-  const r2 = Math.random();
-  const text = r > .5 ? 0 : 1;
-  return {bg: interpolateMagma(r), text: interpolateMagma(text), index};
-}
-
-let colors = Array.from({length:3}).map(generateColor);
-
-function remove(i) {
-  return () => {
-    colors = colors.filter((di) => di.index !== i );
+  function generateColor() {
+    const index = Math.random();
+    const value = Math.random();
+    const text = value > 0.5 ? 0 : 1;
+    return {
+      value,
+      bg: interpolateMagma(value),
+      text: interpolateMagma(text),
+      index,
+    };
   }
-}
 
+  let colors = Array.from({ length: 3 }).map(generateColor);
+
+  function remove(i) {
+    return () => {
+      colors = colors.filter((di) => di.index !== i);
+    };
+  }
 </script>
 
 <style>
-h2 {
-  margin:0px;
-}
+  h2 {
+    margin: 0px;
+  }
 
-.color {
-  --bg: transparent;
-  --text: black;
-  background-color: var(--bg);
-  color: var(--text);
-  border: none;
-  transition: box-shadow 100ms;
-}
+  .color {
+    --bg: transparent;
+    --text: black;
+    background-color: var(--bg);
+    color: var(--text);
+    border: none;
+    transition: box-shadow 100ms;
+  }
 
-.color:hover {
-  box-shadow: 3px 3px 0px var(--hover);
-}
+  .color:hover {
+    box-shadow: 3px 3px 0px var(--hover);
+  }
 </style>
 
-
-<Stack space={4} justifyContent=start justifyItems=start>
+<Stack space={4} justifyContent="start" justifyItems="start">
   <h2>Color Palette</h2>
-  <Button level=medium on:click={() => { colors = [...colors, generateColor()]}}>add color <Add size=1em /></Button>
+  <DataGraphic
+    xType="linear"
+    yType="scaleBand"
+    yDomain={['Magma']}
+    xDomain={[0, 1]}
+    width={200}
+    height={50}
+    top={0}
+    left={4}>
+    <Axis side="bottom" lineStyle="long" tickColor="var(--cool-gray-200)" />
+    <Axis side="left" />
+    {#each colors as color, i (color.bg)}
+      <g transition:fade={{ duration: 200 }}>
+        <Point x={color.value} y="Magma" color={color.bg} size={3} stroke={interpolateMagma(0)} strokeWidth={1} strokeAlpha={.5} />
+      </g>
+    {/each}
+  </DataGraphic>
+  <Button
+    level="medium"
+    on:click={() => {
+      colors = [...colors, generateColor()];
+    }}>
+    add color
+    <Add size="1em" />
+  </Button>
   <div style="width: var(--space-24x);">
-<Stack>
-  {#each colors as { bg, text, index}, i (index)}
-    <button on:click={remove(index)} transition:slide={{duration: 500}} class=color style="--bg:{bg}; --text: {text};">
-      {bg}
-    </button>
-  {/each}
-</Stack>
-</div>
+    <Stack>
+      {#each colors as { bg, text, index }, i (index)}
+        <button
+          on:click={remove(index)}
+          transition:slide={{ duration: 200 }}
+          class="color"
+          style="--bg:{bg}; --text: {text};">
+          {bg}
+        </button>
+      {/each}
+    </Stack>
+  </div>
 
 </Stack>

--- a/packages/stack/stories/Stack.stories.js
+++ b/packages/stack/stories/Stack.stories.js
@@ -1,66 +1,73 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { withKnobs, select } from "@storybook/addon-knobs";
 import StackStory from "./StackStory.svelte";
+import ColorPaletteStory from "./ColorPalette.svelte";
 
 export default {
   title: "Stack",
   decorators: [withKnobs],
 };
 
+const controls = () => ({
+  space: select("space", [
+    1,
+    2,
+    3,
+    4,
+    6,
+    8,
+    12,
+    16,
+    20,
+    24,
+    32,
+    40,
+    48,
+    72,
+    81,
+    96,
+  ]),
+  justifyItems: select("justify items", [
+    "auto",
+    "normal",
+    "stretch",
+    "center",
+    "start",
+    "end",
+  ]),
+  justifyContent: select("justify content", [
+    "stretch",
+    "start",
+    "center",
+    "space-between",
+    "space-around",
+    "space-evenly",
+    "left",
+    "right",
+  ]),
+  alignItems: select("align items", [
+    "normal",
+    "stretch",
+    "center",
+    "start",
+    "end",
+  ]),
+  alignContent: select("align content", [
+    "stretch",
+    "center",
+    "start",
+    "end",
+    "space-between",
+    "space-around",
+    "space-evenly",
+  ]),
+});
+
 export const Default = () => ({
   Component: StackStory,
-  props: {
-    space: select("space", [
-      1,
-      2,
-      3,
-      4,
-      6,
-      8,
-      12,
-      16,
-      20,
-      24,
-      32,
-      40,
-      48,
-      72,
-      81,
-      96,
-    ]),
-    justifyItems: select("justify items", [
-      "auto",
-      "normal",
-      "stretch",
-      "center",
-      "start",
-      "end",
-    ]),
-    justifyContent: select("justify content", [
-      "stretch",
-      "start",
-      "center",
-      "space-between",
-      "space-around",
-      "space-evenly",
-      "left",
-      "right",
-    ]),
-    alignItems: select("align items", [
-      "normal",
-      "stretch",
-      "center",
-      "start",
-      "end",
-    ]),
-    alignContent: select("align content", [
-      "stretch",
-      "center",
-      "start",
-      "end",
-      "space-between",
-      "space-around",
-      "space-evenly",
-    ]),
-  },
+  props: controls(),
+});
+
+export const ColorPalette = () => ({
+  Component: ColorPaletteStory,
 });

--- a/packages/stack/style.css
+++ b/packages/stack/style.css
@@ -6,9 +6,24 @@
   --align-items: normal;
   --align-content: start;
   display: grid;
-  grid-row-gap: var(--space);
   justify-items: var(--justify-items);
   justify-content: var(--justify-content);
   align-items: var(--align-items);
   align-content: var(--align-content);
+}
+
+/*
+This approach, while a bit more involved than setting margin-top for * + *,
+does allow all elements in the stack to smoothly transition using svelte's
+slide.
+*/
+
+.gp-stack > * {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.gp-stack > * + *,
+.gp-stack > :first-child {
+  margin-bottom: var(--space);
 }

--- a/packages/stack/style.css
+++ b/packages/stack/style.css
@@ -18,12 +18,15 @@ does allow all elements in the stack to smoothly transition using svelte's
 slide.
 */
 
+.gp-stack:only-child {
+  height: 100%;
+}
+
 .gp-stack > * {
   margin-top: 0px;
   margin-bottom: 0px;
 }
 
-.gp-stack > * + *,
-.gp-stack > :first-child {
-  margin-bottom: var(--space);
+.gp-stack > * + * {
+  margin-top: var(--space);
 }


### PR DESCRIPTION
Closes #35

Re-implements the `Stack` component to use an owl selector instead of `grid-column-gap`. The stack itself, however, is sitll implemented in CSS grid, giving flexibiilty w/ the same the justify / align props. This allows the spacing to be collapsed in various ways when transitioning in a new element. See the `ColorPalette.svelte` story as an example.

Practically speaking, this should have no visual effect for end users.