### PR TITLE
Allow option menus to gain/lose options after instantiation

### DIFF
--- a/packages/optionmenu/Option.svelte
+++ b/packages/optionmenu/Option.svelte
@@ -21,21 +21,21 @@
   // Just a little more readable
   const enabled = !disabled;
 
-  // If the enabled status of this option changed, update the enabledOptions
-  // store
-  $: if (enabled && !enabledOptions.has(key)) {
-    enabledOptions.add(key, label);
-  } else if (!enabled && enabledOptions.has(key)) {
-    enabledOptions.remove(key);
-  }
+  enabledOptions.subscribe(() => {
+    if (enabled && !enabledOptions.has(key)) {
+      enabledOptions.add(key, label);
+    } else if (!enabled && enabledOptions.has(key)) {
+      enabledOptions.remove(key);
+    }
+  });
 
-  // If this option is enabled the selected status changed, update the
-  // selectedOptions store
-  $: if (enabled && selected && !selectedOptions.has(key)) {
-    selectedOptions.add(key, label);
-  } else if (enabled && !selected && selectedOptions.has(key)) {
-    selectedOptions.remove(key);
-  }
+  selectedOptions.subscribe(() => {
+    if (enabled && selected && !selectedOptions.has(key)) {
+      selectedOptions.add(key, label);
+    } else if (enabled && !selected && selectedOptions.has(key)) {
+      selectedOptions.remove(key);
+    }
+  });
 </script>
 
 <MenuListItem {compact} {key} value={label} hoverable={!disabled}>

--- a/packages/optionmenu/OptionMenu.svelte
+++ b/packages/optionmenu/OptionMenu.svelte
@@ -1,6 +1,7 @@
 <script>
   // eslint-disable-next-line import/no-extraneous-dependencies
   import { createEventDispatcher, setContext } from "svelte";
+  import { afterUpdate } from "svelte";
   import { CaretDown } from "@graph-paper/icons";
   import { FloatingMenu, MenuList } from "@graph-paper/menu";
   import { onClickOutside } from "@graph-paper/core/utils";
@@ -67,6 +68,11 @@
       dispatch("selection", { key });
     }
   }
+  afterUpdate(() => {
+    // reset any options after updating, in case they've changed
+    selectedOptions.reset();
+    enabledOptions.reset();
+  });
 
   /**
    * Return an array containing all numbers between two numbers, inclusive.


### PR DESCRIPTION
It can be useful to dynamically add options to a menu (e.g. to
add a specific range of dates at runtime to a daterange selector)

Previously if you created an option menu, then added some
additional options to it, you would have strange undefined behaviour.