### PR TITLE
Increase DataGraphic svg container size to accommodate large numbers

### DIFF
--- a/packages/datagraphic/DataGraphic.svelte
+++ b/packages/datagraphic/DataGraphic.svelte
@@ -402,7 +402,7 @@
   class="data-graphic-container"
   style="width: {$graphicWidth}px; height: {$graphicHeight}px;">
   <svg
-    style="width: {$graphicWidth}px; height: {$graphicHeight}px;"
+    style="width: {$graphicWidth + 90}px; height: {$graphicHeight}px;"
     bind:this={svg}
     shape-rendering="auto"
     viewbox="0 0 {$graphicWidth}


### PR DESCRIPTION
GLAM doesn't handle large numbers on the y-axis very well. Eg: https://glam.telemetry.mozilla.org/fenix/probe/startup_timeline_framework_primary/explore?ping_type=*:

![CleanShot 2021-06-22 at 18 54 47@2x](https://user-images.githubusercontent.com/28797553/123022914-5f6fa800-d38b-11eb-9fb7-9147053f1f10.png)

To fix it, I added a little more width to the SVG canvas so that it takes up all the available space. The data graphic container still scales responsively with this change. 

<img width="619" alt="CleanShot 2021-06-22 at 18 51 17@2x" src="https://user-images.githubusercontent.com/28797553/123022606-df494280-d38a-11eb-865b-0e1432ed7bd1.png">
